### PR TITLE
Allow white spaces to show so that one position text-based emojis better 😄 

### DIFF
--- a/src/components/SelectionArea.js
+++ b/src/components/SelectionArea.js
@@ -24,8 +24,9 @@ function getTextStyle(data) {
     const size = {fontSize: data.fontSize}
     const color = {color: data.textColor}
     const fontFamily = {fontFamily: data.fontFamily}
+    const showWhitespaces = { "white-space": "pre" }
 
-    return Object.assign({}, size, color, fontFamily)
+    return Object.assign({}, size, color, fontFamily, showWhitespaces)
 }
 
 class SelectionArea extends Component {

--- a/src/components/SelectionArea.js
+++ b/src/components/SelectionArea.js
@@ -24,9 +24,9 @@ function getTextStyle(data) {
     const size = {fontSize: data.fontSize}
     const color = {color: data.textColor}
     const fontFamily = {fontFamily: data.fontFamily}
-    const showWhitespaces = { whiteSpace: "pre" }
-
-    return Object.assign({}, size, color, fontFamily, showWhitespaces)
+    const baseStyles = { whiteSpace: "pre" }
+    
+    return Object.assign(baseStyles, size, color, fontFamily)
 }
 
 class SelectionArea extends Component {

--- a/src/components/SelectionArea.js
+++ b/src/components/SelectionArea.js
@@ -24,7 +24,7 @@ function getTextStyle(data) {
     const size = {fontSize: data.fontSize}
     const color = {color: data.textColor}
     const fontFamily = {fontFamily: data.fontFamily}
-    const showWhitespaces = { "white-space": "pre" }
+    const showWhitespaces = { whiteSpace: "pre" }
 
     return Object.assign({}, size, color, fontFamily, showWhitespaces)
 }


### PR DESCRIPTION
:wave: @crinjely,

first of all I like to thank you so much for your ✨ project. My daughter Sophie is a HUGE Roblox fan like you and is having her 10th birthday this weekend. She is designing all kind of T-shirts for her groups ([like this one](https://www.roblox.com/groups/9393178/Die-Blaupastelschmetterlingfashionistas#!/about)) and knows how time consuming this can be. Your app will be an amazing birthday present for her: https://roblox-444galaxygirl.herokuapp.com/about/

I would also like to give you something back for your app in the spirit of true Open Source: When trying out the text feature in your app, I noticed that white spaces at the beginning of a text get ignored. This makes it harder to position emojis in the center of the shirt. Sophie figured that emojis are often the easiest way to create fancy T-Shirts because [there are so many of them](https://getemoji.com/), and they scale with the font size:

![image](https://user-images.githubusercontent.com/1872314/112870134-2d1d1a00-90be-11eb-9580-011862ff7b7b.png)

If you merge this pull request, you will be able to position text based emojis using white spaces as well 🎉 

Thanks again for your wonderful project

:octocat: ❤️ 

/cc @assafweinberg thank you so much for introducing kids into tech, you may also like https://myoctocat.dev/